### PR TITLE
Initialize logger before optional openfood import

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,14 @@ from pathlib import Path
 from dotenv import load_dotenv
 from openai import OpenAI
 
+# ========= ЛОГИ =========
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    handlers=[logging.FileHandler("bot.log", encoding="utf-8"), logging.StreamHandler()],
+)
+logger = logging.getLogger("healco-lite")
+
 # Импортируем Open Food Facts модуль
 try:
     from openfood import off_by_barcode, off_search_by_name, set_user_agent
@@ -52,14 +60,6 @@ from telegram.ext import (
     filters,
     PreCheckoutQueryHandler,
 )
-
-# ========= ЛОГИ =========
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    handlers=[logging.FileHandler("bot.log", encoding="utf-8"), logging.StreamHandler()],
-)
-logger = logging.getLogger("healco-lite")
 
 VERSION = "healco lite v1.2"
 PROJECT_NAME = "Healco Lite v1.2"


### PR DESCRIPTION
## Summary
- Configure logging and initialize `logger` before attempting to import `openfood`
- Ensure import failures are logged using the initialized logger

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c56ac05704832dac398d6fb4ddce4d