### PR TITLE
Default to OpenAI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Key packages include:
 
 ```
 export OPENAI_API_KEY=your_openai_key
+export LLM_PROVIDER=openai  # optional, defaults to openai; set to gemini to use Gemini
 export TELEGRAM_BOT_TOKEN=your_bot_token
 export TELEGRAM_PAYMENT_PROVIDER_TOKEN=your_payment_token
 export DEVELOPER_USER_ID=123456789
@@ -43,8 +44,11 @@ export EXTERNAL_JSONL_URL=...
 export GDRIVE_ID=...
 export FATSECRET_KEY=...
 export FATSECRET_SECRET=...
-export GEMINI_API_KEY=...
+export GEMINI_API_KEY=...  # required if LLM_PROVIDER=gemini
 ```
+
+OpenAI is used by default. Set `LLM_PROVIDER=gemini` and provide `GEMINI_API_KEY`
+if you want to use the Gemini-compatible API instead.
 
 3. Run the bot:
 

--- a/main.py
+++ b/main.py
@@ -4945,7 +4945,8 @@ async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE):
 # LLM client factory
 # =========================
 
-LLM_PROVIDER = os.getenv("LLM_PROVIDER", "gemini").strip().lower()  # "openai" | "gemini"
+# По умолчанию используем OpenAI. Установите LLM_PROVIDER=gemini для Gemini API.
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").strip().lower()  # "openai" | "gemini"
 GEMINI_API_KEY = get_secret("GEMINI_API_KEY", "")
 GEMINI_BASE_URL = os.getenv(
     "GEMINI_BASE_URL",


### PR DESCRIPTION
## Summary
- Use OpenAI as the default LLM provider and document how to switch to Gemini
- Note OpenAI as the default in README environment setup and clarify Gemini usage

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c56f01d460832d9f7073db22e80c76