### PR TITLE
Raise threshold for Google product search relevance

### DIFF
--- a/main.py
+++ b/main.py
@@ -1618,7 +1618,8 @@ async def search_google_for_product(query: str) -> Optional[Dict[str, Any]]:
                 text_content = f"{title} {snippet}"
 
                 relevance_score = calculate_relevance_score(text_content, clean_query)
-                if relevance_score < 0.3:
+                # Пропускаем результаты с низкой релевантностью (< 0.9)
+                if relevance_score < 0.9:
                     continue
 
                 nutrition_data = extract_nutrition_from_text(text_content.lower(), clean_query)


### PR DESCRIPTION
## Summary
- Increase acceptable relevance score from 0.3 to 0.9 in Google product search
- Document new relevance requirement to skip low-quality results

## Testing
- `pytest`
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5cd053ca0832da1aba83fff2c4043