### PR TITLE
Ensure product name fallback to user query

### DIFF
--- a/main.py
+++ b/main.py
@@ -4806,6 +4806,7 @@ async def handle_text_or_photo(update: Update, context: ContextTypes.DEFAULT_TYP
                     return res
                 # привести к единому виду и досчитать «на порцию»
                 search_result = _scale_portion(dict(search_result), text)
+                search_result.setdefault('name', text)
 
                 source_map = {
                     'google_cse_jsonld': '🔎 Google (JSON-LD)',
@@ -4817,7 +4818,7 @@ async def handle_text_or_photo(update: Update, context: ContextTypes.DEFAULT_TYP
 
                 lines = [
                     f"✅ Найден продукт:",
-                    f"📦 {search_result.get('name') or '—'}",
+                    f"📦 {search_result['name']}",
                 ]
 
                 if search_result.get('brand'):


### PR DESCRIPTION
## Summary
- Set product name to the user query when search results lack a name
- Always display the name in result lines

## Testing
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5cd0c3778832d971a4e2de738d93a