### PR TITLE
Add Pydantic dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ python-dotenv==1.0.1
 python-telegram-bot==21.4
 requests==2.32.3
 requests-oauthlib==1.3.1
-
+pydantic==2.7.4
+pydantic-core==2.18.4


### PR DESCRIPTION
## Summary
- add pydantic and pydantic-core to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pydantic==2.7.4; Tunnel connection failed: 403 Forbidden)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7f6bfc640832d8f88d0e0bd24cfd9