### PR TITLE
Add missing Open Food Facts dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ python-dotenv==1.0.1
 python-telegram-bot==21.4
 requests==2.32.3
 requests-oauthlib==1.3.1
-
+openfoodfacts


### PR DESCRIPTION
## Summary
- include `openfoodfacts` in project requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openfoodfacts)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f6c14360832db1acfe6881a63b56