### PR TITLE
Enforce required TELEGRAM_BOT_TOKEN and document requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Key packages include:
 ```
 export OPENAI_API_KEY=your_openai_key
 export LLM_PROVIDER=openai  # optional, defaults to openai; set to gemini to use Gemini
-export TELEGRAM_BOT_TOKEN=your_bot_token
+export TELEGRAM_BOT_TOKEN=your_bot_token  # required
 export TELEGRAM_PAYMENT_PROVIDER_TOKEN=your_payment_token
 export DEVELOPER_USER_ID=123456789
 # Optional integrations
@@ -46,6 +46,8 @@ export FATSECRET_KEY=...
 export FATSECRET_SECRET=...
 export GEMINI_API_KEY=...  # required if LLM_PROVIDER=gemini
 ```
+
+`TELEGRAM_BOT_TOKEN` is mandatory — the application will exit immediately if it is not set.
 
 OpenAI is used by default. Set `LLM_PROVIDER=gemini` and provide `GEMINI_API_KEY`
 if you want to use the Gemini-compatible API instead.

--- a/main.py
+++ b/main.py
@@ -6209,8 +6209,7 @@ def start_keepalive_server():
 # ========= ЗАПУСК =========
 def main():
     if not BOT_TOKEN:
-        print("Ошибка: не задан TELEGRAM_BOT_TOKEN")
-        return
+        raise SystemExit("Ошибка: не задан TELEGRAM_BOT_TOKEN")
     if not TELEGRAM_PAYMENT_PROVIDER_TOKEN:
         print("Внимание: не задан TELEGRAM_PAYMENT_PROVIDER_TOKEN. Платёжные функции будут недоступны.")
 


### PR DESCRIPTION
## Summary
- terminate startup with `SystemExit` if `TELEGRAM_BOT_TOKEN` is missing
- document that `TELEGRAM_BOT_TOKEN` is a required variable

## Testing
- `python -m py_compile main.py`
- `python main.py && echo done` *(fails with missing TELEGRAM_BOT_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f81c2028832db90ce2889dbecf70