### PR TITLE
Pin Open Food Facts dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiohttp==3.9.5
 flask==3.0.3
 httpx==0.27.0
 openai==1.40.2
+openfoodfacts==0.2.1
 python-dotenv==1.0.1
 python-telegram-bot==21.4
 requests==2.32.3


### PR DESCRIPTION
## Summary
- add explicit versioned openfoodfacts package

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openfoodfacts==0.2.1 due to proxy 403)*
- `pip install -r requirements.txt --index-url https://pypi.org/simple --trusted-host pypi.org` *(fails: Could not find a version that satisfies the requirement openfoodfacts==0.2.1 due to proxy 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7f7e0e584832d9c8623c12d10c61a