### PR TITLE
Translate Cyrillic FatSecret queries

### DIFF
--- a/main.py
+++ b/main.py
@@ -1386,8 +1386,15 @@ async def search_branded_product_via_google(
             if c:
                 logger.info(f"FatSecret cache hit by query {clean}")
                 return c
-                
-            food = await _fs_search_best(clean)
+
+            fs_query = clean
+            if re.search(r"[А-Яа-я]", clean):
+                fs_query = _translate_ru_to_en(clean)
+                logger.info(
+                    f"Translated Cyrillic query for FatSecret search: {fs_query}"
+                )
+
+            food = await _fs_search_best(fs_query)
             if food:
                 logger.info(f"Found FatSecret food: {food.get('food_name', 'Unknown')}")
                 res = _fs_norm(food, g, ml)


### PR DESCRIPTION
## Summary
- translate FatSecret search queries containing Cyrillic characters before invoking the FatSecret API helper
- log the translated query used for the FatSecret search

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68c88b83bf9c832d8ad9d169858066af