### PR TITLE
Add async LLM helper for Russian to English translation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1669,6 +1669,28 @@ def _translate_en_to_ru(text: str) -> str:
             return ru
     return text
 
+async def _translate_ru_to_en_llm(text: str) -> str:
+    """Переводит текст с русского на английский через LLM с запасным вариантом."""
+    if not text:
+        return text
+
+    if not client:
+        return text
+
+    try:
+        response = await chat_llm(
+            [
+                {"role": "system", "content": "You translate Russian text to concise English."},
+                {"role": "user", "content": f"Переведи на английский и ответь только переводом: {text}"},
+            ],
+            temperature=0,
+        )
+        translation = response.strip()
+        return translation or text
+    except Exception as e:
+        logger.warning(f"LLM translation failed: {e}")
+        return text
+
 async def translate_clean_query(clean_query: str) -> Tuple[str, str]:
     """Возвращает английскую и русскую версии запроса."""
     en = clean_query


### PR DESCRIPTION
## Summary
- add an async `_translate_ru_to_en_llm` helper that leverages `chat_llm` for Russian to English translation
- ensure the helper falls back to the original text when the LLM client is unavailable or returns an empty response

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68c960a9dea8832d9a2a9e1bc48bbeb5