### PR TITLE
Short-circuit FatSecret search on high similarity match

### DIFF
--- a/main.py
+++ b/main.py
@@ -2548,6 +2548,11 @@ async def _fs_search_best(query: str) -> dict | None:
         if similarity < 0.5:
             continue
         metric_score = _metric_score(candidate)
+        if similarity >= 0.9:
+            best_food = candidate
+            best_similarity = similarity
+            best_metric_score = metric_score
+            break
         if (
             similarity > best_similarity
             or (similarity == best_similarity and metric_score > best_metric_score)


### PR DESCRIPTION
## Summary
- short circuit the FatSecret search loop when a candidate reaches a very high similarity score
- ensure the top-scoring candidate's metadata is captured before exiting the loop

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9614a7928832daa0d6bba10a79c73