### PR TITLE
Update default LLM model

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,10 +66,12 @@ from telegram.ext import (
 
 VERSION = "healco lite v1.2"
 PROJECT_NAME = "Healco Lite v1.2"
-MODEL_NAME = "gpt-4o-mini"
+MODEL_NAME_DEFAULT = "gpt-5-mini"
 
 # ========= ENV =========
 load_dotenv()
+
+MODEL_NAME = os.environ.get("MODEL_NAME", MODEL_NAME_DEFAULT)
 
 # ========= FALLBACK NUTRITION DATA =========
 BASIC_PRODUCTS: Dict[str, Dict[str, Any]] = {


### PR DESCRIPTION
## Summary
- update the default LLM model name to `gpt-5-mini`
- allow overriding the model name via the `MODEL_NAME` environment variable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68caa1805984832dbedcaec87d07dd23