### PR TITLE
Update default OpenAI model to gpt-5-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Key packages include:
 ```
 export OPENAI_API_KEY=your_openai_key
 export LLM_PROVIDER=openai  # optional, defaults to openai; set to gemini to use Gemini
+export MODEL_NAME=gpt-5-mini  # optional, defaults to gpt-5-mini
 export TELEGRAM_BOT_TOKEN=your_bot_token  # required
 export TELEGRAM_PAYMENT_PROVIDER_TOKEN=your_payment_token
 export DEVELOPER_USER_ID=123456789
@@ -49,7 +50,7 @@ export GEMINI_API_KEY=...  # required if LLM_PROVIDER=gemini
 
 `TELEGRAM_BOT_TOKEN` is mandatory — the application will exit immediately if it is not set.
 
-OpenAI is used by default. Set `LLM_PROVIDER=gemini` and provide `GEMINI_API_KEY`
+OpenAI is used by default with the `gpt-5-mini` model. Set `LLM_PROVIDER=gemini` and provide `GEMINI_API_KEY`
 if you want to use the Gemini-compatible API instead.
 
 3. Run the bot:

--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ from telegram.ext import (
 
 VERSION = "healco lite v1.2"
 PROJECT_NAME = "Healco Lite v1.2"
+# Default OpenAI chat model to use when MODEL_NAME is not set
 MODEL_NAME_DEFAULT = "gpt-5-mini"
 
 # ========= ENV =========


### PR DESCRIPTION
## Summary
- document the new default OpenAI chat model value `gpt-5-mini` in the README environment variable examples
- clarify that the application defaults to the `gpt-5-mini` model and annotate the constant in `main.py`

## Testing
- not run (OpenAI API key unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68caa8ad5e80832da3bbbab4edd9c632