### PR TITLE
Fix portion unit handling when macros missing

### DIFF
--- a/main.py
+++ b/main.py
@@ -1931,6 +1931,8 @@ async def search_google_for_product(
                         if amount is None or amount <= 0:
                             return False
 
+                        result[portion_key] = amount
+
                         base_kcal = result.get(f'kcal_{base_suffix}')
                         base_protein = result.get(f'protein_{base_suffix}')
                         base_fat = result.get(f'fat_{base_suffix}')
@@ -1944,21 +1946,23 @@ async def search_google_for_product(
                         ):
                             return False
 
-                        if not result.get(portion_key):
-                            result[portion_key] = amount
-
                         factor = amount / 100.0
+
+                        macros_written = False
 
                         if base_kcal is not None:
                             result['kcal_portion'] = base_kcal * factor
+                            macros_written = True
                         if base_protein is not None:
                             result['protein_portion'] = base_protein * factor
+                            macros_written = True
                         if base_fat is not None:
                             result['fat_portion'] = base_fat * factor
+                            macros_written = True
                         if base_carbs is not None:
                             result['carbs_portion'] = base_carbs * factor
 
-                        return True
+                        return macros_written
 
                     applied = _apply_portion_values(
                         nutrition_data,

--- a/tests/test_search_google.py
+++ b/tests/test_search_google.py
@@ -1,0 +1,62 @@
+import asyncio
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import main
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self.status_code = 200
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_search_google_portion_ml_retained(monkeypatch):
+    monkeypatch.setattr(main, "GOOGLE_CSE_KEY", "test-key")
+    monkeypatch.setattr(main, "GOOGLE_CSE_CX", "test-cx")
+    monkeypatch.setattr(main, "is_branded_product", lambda query: False)
+
+    async def fake_translate_clean_query(clean_query: str):
+        return clean_query, clean_query
+
+    monkeypatch.setattr(main, "translate_clean_query", fake_translate_clean_query)
+
+    def fake_requests_get(url, params=None, timeout=None):
+        return DummyResponse(
+            {
+                "items": [
+                    {
+                        "title": "Sample Juice",
+                        "snippet": (
+                            "Sample juice provides 40 kcal per 100 g, protein 1 g, "
+                            "fat 0 g, carbs 9 g."
+                        ),
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr(main.requests, "get", fake_requests_get)
+
+    async def run_search():
+        return await main.search_google_for_product("sample juice", ml=250)
+
+    result = asyncio.run(run_search())
+
+    assert result is not None
+    assert result.get("portion_ml") == 250
+
+    portion_line = (
+        f"⚖️ Порция: {int(result.get('portion_g') or 0)} г"
+        if result.get("portion_g")
+        else f"⚖️ Порция: {int(result.get('portion_ml') or 0)} мл"
+    )
+
+    assert portion_line == "⚖️ Порция: 250 мл"


### PR DESCRIPTION
## Summary
- store user-specified portion amounts before checking macro availability so values persist even when per-100 data is absent
- added regression test covering ml-based portions and verifying the formatted output uses the provided volume

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb29c09980832dba025592094ab22e