### PR TITLE
Add traceback import for search error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ import random
 import requests
 import httpx
 import difflib
+import traceback
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, Any, List, Optional, Tuple


### PR DESCRIPTION
## Summary
- add the missing traceback import so new error formatting calls succeed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceca4cb2bc832db8470ce8693c18da