### PR TITLE
Align branded Google CSE query with incoming search text

### DIFF
--- a/main.py
+++ b/main.py
@@ -1004,7 +1004,7 @@ async def _google_cse_search_branded(q: str, num: int = 8) -> List[str]:
         params = {
             "key": GOOGLE_CSE_KEY,
             "cx": GOOGLE_CSE_CX,
-            "q": f"{domains} {negative}",
+            "q": f"{q} {domains} {negative}",
             "num": min(10, num),
             "exactTerms": exact,
             "orTerms": or_terms,


### PR DESCRIPTION
## Summary
- update the branded Google CSE search helper to include the incoming query text alongside the domain and negative filters so the API looks for the requested product within the curated sites

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cecf938648832d8680a8ae3535b6ef