### PR TITLE
Group domain filter in branded CSE query

### DIFF
--- a/main.py
+++ b/main.py
@@ -998,13 +998,23 @@ async def _google_cse_search_branded(q: str, num: int = 8) -> List[str]:
         brand_tokens = [t for t in re.split(r"[\s,]+", q) if len(t) > 2]
         exact = " ".join(brand_tokens[:4])  # короткая фраза в exactTerms
         or_terms = "калории|пищевая ценность|КБЖУ|nutrition facts|питательная ценность \"на 100 г\""
-        domains = "site:ozon.ru OR site:wildberries.ru OR site:vkusvill.ru OR site:perekrestok.ru OR site:lenta.com OR site:5ka.ru OR site:metro-cc.ru OR site:auchan.ru"
+        domain_list = [
+            "ozon.ru",
+            "wildberries.ru",
+            "vkusvill.ru",
+            "perekrestok.ru",
+            "lenta.com",
+            "5ka.ru",
+            "metro-cc.ru",
+            "auchan.ru",
+        ]
+        domains = " OR ".join(f"site:{domain}" for domain in domain_list)
         negative = "-inurl:questions -inurl:reviews -inurl:otzyv -inurl:forum"
 
         params = {
             "key": GOOGLE_CSE_KEY,
             "cx": GOOGLE_CSE_CX,
-            "q": f"{q} {domains} {negative}",
+            "q": f"({q}) ({domains}) {negative}",
             "num": min(10, num),
             "exactTerms": exact,
             "orTerms": or_terms,


### PR DESCRIPTION
## Summary
- refactor branded Google CSE search to build domain filters from a list and wrap them in parentheses
- ensure the user query is grouped with domain constraints while preserving negative filters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ced106ed98832d8c85eb5c72f57a89