### PR TITLE
Unify meal logging with photo analysis and brand portion prompts

### DIFF
--- a/main.py
+++ b/main.py
@@ -6068,6 +6068,10 @@ async def analyze_meal_photo(bot, file_id: str, profile: Dict[str, Any]) -> Opti
                     }
 
     # 2. Fallback на Google Cloud Vision API
+    if not VISION_KEY:
+        logger.warning("Vision API fallback skipped: VISION_KEY is not configured")
+        return None
+
     labels = await asyncio.to_thread(_vision_detect_labels, image_bytes)
     if not labels:
         logger.warning("Vision API fallback did not return any labels")
@@ -6104,7 +6108,6 @@ async def analyze_meal_photo(bot, file_id: str, profile: Dict[str, Any]) -> Opti
 def _vision_detect_labels(image_content: bytes, max_results: int = 5) -> List[str]:
     """Получает ярлыки блюда через Google Cloud Vision API."""
     if not VISION_KEY:
-        logger.warning("VISION_KEY is not set for Vision API fallback")
         return []
 
     endpoint = f"https://vision.googleapis.com/v1/images:annotate?key={VISION_KEY}"


### PR DESCRIPTION
## Summary
- replace the nutritionist menu buttons with a single "Записать приём пищи" entry point and update the handler to launch the new flow
- merge diary updates and product search into a shared `log_food_entry` state that supports barcode lookup, brand prompts for missing portions, and new `brand_portion_input` handling
- add `analyze_meal_photo` to estimate meals from photos and extend the aggregator with a `needs_grams` flag for branded items without known weight
- add a Google Cloud Vision API fallback that labels meal photos and estimates macros when OpenAI vision is unavailable

## Testing
- `python -m compileall main.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd40d4bea4832d8eaba5dbbf7ed324